### PR TITLE
PR-small_features

### DIFF
--- a/preview-audio.yazi/main.lua
+++ b/preview-audio.yazi/main.lua
@@ -2,7 +2,6 @@
 
 local M = {}
 
--- TODO: implement cache
 local audio_ffprobe = function(file)
   -- stylua: ignore
   local cmd = Command('ffprobe'):arg {
@@ -27,6 +26,13 @@ local audio_ffprobe = function(file)
 
   local stream = json.streams[1]
   local tags = json.format.tags or stream.tags or stream
+  local duration = json.format.duration
+  if duration then
+      duration = tonumber(duration)
+      local minutes = math.floor(duration / 60)
+      local seconds = math.floor(duration % 60)
+      duration = string.format("%d:%02d", minutes, seconds)
+  end
 
   local data = {}
   local title, album, aar, ar =
@@ -52,15 +58,18 @@ local audio_ffprobe = function(file)
     end
 
     data = {
-      ui.Line(string.format('%s - %s', artist, title)),
+      ui.Line(string.format('%s - %s', artist, title)):fg("#FF4C4C"):bold(),
+      ui.Line(string.format('%s: %s', 'Duration', duration)),
       ui.Line(string.format('%s: %s', 'Album', album)),
-      ui.Line(string.format('%s: %s', 'Genre', tags.GENRE or tags.genre)),
+      ui.Line(string.format('%s: %s', 'Genre', tags.GENRE or tags.genre or "No genre")),
       ui.Line(string.format('%s: %s', 'Date', date)),
       c ~= '' and ui.Line(string.format('%s: %s', 'Cover art', c)) or nil,
     }
   end
 
   local br = tonumber((json.format.bit_rate or 0) // 1000) .. ' kb/s'
+  table.insert(data, ui.Line(""))
+  table.insert(data, ui.Line("Specs:"):fg("#858585"))
   table.insert(data, ui.Line(string.format('%s: %s', 'Format', json.format.format_name)))
   table.insert(data, ui.Line(string.format('%s: %s', 'BitRate', br)))
   table.insert(data, ui.Line(string.format('%s: %s', 'Channels', tostring(stream.channels or '?'))))

--- a/spot-audio.yazi/main.lua
+++ b/spot-audio.yazi/main.lua
@@ -27,6 +27,13 @@ local audio_ffprobe = function(file)
 
   local stream = json.streams[1]
   local tags = json.format.tags or stream.tags or stream
+  local duration = json.format.duration
+  if duration then
+      duration = tonumber(duration)
+      local minutes = math.floor(duration / 60)
+      local seconds = math.floor(duration % 60)
+      duration = string.format("%d:%02d", minutes, seconds)
+  end
 
   local data = {} ---@type Sections
   local title, album, aar, ar =
@@ -37,7 +44,7 @@ local audio_ffprobe = function(file)
 
   if title .. album .. ar .. aar ~= '' then
     local cdata = json.streams[2]
-    local date = tags.DATE or tags.date or ''
+    local date = tags.DATE or tags.date or 'No date'
     local c = ''
     local artist = ar
 
@@ -53,11 +60,12 @@ local audio_ffprobe = function(file)
 
     data[#data + 1] = {
       title = 'General',
-      { 'Title', title },
+      { 'Title', ui.Line(title):bold()},
       { 'Album', album },
       { 'Artist', artist },
-      { 'Genre', tags.GENRE or tags.genre },
-      { 'Date', date },
+      { 'Genre', tags.GENRE or tags.genre or "No genre"},
+      { 'Date', date},
+      { 'Duration', duration },
       c ~= '' and { 'Cover art', c } or nil,
     }
   end
@@ -121,6 +129,7 @@ local audio_mediainfo = function(file)
       { 'Artist', ar .. (aar ~= ar and (' / ' .. aar) or '') },
       { 'Genre', general.Genre },
       { 'Date', date },
+      { 'Duration', general.Duration },
       csize ~= '' and { 'Cover art', csize } or nil,
     }
   end
@@ -133,7 +142,7 @@ local audio_mediainfo = function(file)
     { 'Quality', (audio.BitDepth or '1') .. '/' .. sr },
     { 'BitRate', br },
     { 'Channels', audio.Channels .. ' ' .. (audio.ChannelLayout or '') },
-    -- { 'Duration', audio.Duration },
+    { 'Duration', audio.Duration },
   }
 
   -- ya.dbg(data)

--- a/spot.yazi/README.md
+++ b/spot.yazi/README.md
@@ -46,6 +46,7 @@ in `~/.config/yazi/yazi.toml`
 prepend_spotters = [
   { mime = "audio/*", run = "spot" }, # use the plugin with default settings
   { mime = "video/*", run = "spot-custom" }, # use your custom spotter that you created above
+  { mime = "*", run = "spot" }, # to fallback all the files without a spot-custom, but it maintains the style 
 ]
 ```
 
@@ -59,6 +60,7 @@ require('spot'):setup {
     hash_filesize_limit = 150, -- in MB, set 0 to disable
     relative_time = true,
     time_format = '%Y-%m-%d %H:%M', -- https://www.man7.org/linux/man-pages/man3/strftime.3.html
+    with_header = true,
   },
   plugins_section = {
     enable = true,

--- a/spot.yazi/main.lua
+++ b/spot.yazi/main.lua
@@ -17,6 +17,7 @@ local get_config = ya.sync(function(st)
         hash_filesize_limit = 150, -- in MB, set 0 to disable
         relative_time = true,
         time_format = '%Y-%m-%d %H:%M', -- https://www.man7.org/linux/man-pages/man3/strftime.3.html
+        with_header = true,
       },
       plugins_section = {
         enable = true,
@@ -170,6 +171,36 @@ function M:setup(config)
   set_config(tbl_strict_extend(get_config(), config))
 end
 
+local function get_total_size(urls)
+    local total = 0
+    for _, url in ipairs(urls) do
+        local it = fs.calc_size(url)
+        while true do
+            local next = it:recv()
+            if next then
+                total = total + next
+            else
+                break
+            end
+        end
+    end
+    return total
+end
+
+local function format_size(size)
+    local units = { "B", "KB", "MB", "GB", "TB" }
+    local unit_index = 1
+    while size > 1024 and unit_index < #units do
+        size = size / 1024
+        unit_index = unit_index + 1
+    end
+
+    local str = string.format("%.2f", size)
+    str = string.gsub(str, "(%d),?0*$", "%1")
+    return str .. ' ' .. units[unit_index]
+end
+
+
 ---@param job Job
 ---@param extra table
 ---@param config SpotConf
@@ -203,6 +234,16 @@ function M:render_table(job, extra, config)
     end
   end
 
+  -- Archive
+  if config.metadata_section.with_header then
+    add_section{
+      title = job.file.cha.is_dir and 'Folder' or 'File',
+      {'Size', format_size(get_total_size({job.file.url}))},
+      {'Path', tostring(job.file.path)}
+    }
+  end
+
+  local hashzin = not job.file.cha.is_dir and { 'Hash', hash(job.file, config) } or nil
   -- Metadata
   if config.metadata_section.enable then
     add_section {
@@ -212,7 +253,7 @@ function M:render_table(job, extra, config)
       { 'Created', fileTimestamp(job.file, 'btime', config) },
       { 'Modified', fileTimestamp(job.file, 'mtime', config) },
       { 'Accessed', fileTimestamp(job.file, 'atime', config) },
-      { 'Hash', hash(job.file, config) },
+      hashzin,
     }
   end
 


### PR DESCRIPTION
## spot-audio
Added audio duration to spot-audio and introduced two fallback messages for empty values:
- "No genre"
- "No date"

## preview-audio
Improved the preview layout for better readability and comfort:
- More eye-catching title
- Added audio duration
- Clear spacing between general information and audio specifications

## spot
Added a header to the spot view, similar to the default Yazi spot layout, displaying:
- Title ("Folder" | "File")
- Size
- Path

This is useful because not everyone uses size in line mode, folders do not display size there, and showing the path makes it easier to copy using ["c", "c"], improving overall usability.

I also added a configuration option in init.lua and updated the README.md to document it.  
This setting allows enabling or disabling the header.

Configuration:
```
metadata_section = {
    with_header = boolean
}
```
I removed the hash when the spot item is a folder, because it was always empty.  
Now, the hash field is hidden for directories and only shown for files.