### PR TITLE
preview-cbz: use case-insensitive natural sort

### DIFF
--- a/preview-cbz.yazi/main.lua
+++ b/preview-cbz.yazi/main.lua
@@ -48,7 +48,7 @@ local get_file = function(job)
 
   -- stylua: ignore
   child, err = Command('sort')
-    :arg({ '-n' })
+    :arg({ '-V', '-f' })
     :stdin(stdout)
     :stdout(Command.PIPED)
     :stderr(Command.PIPED)


### PR DESCRIPTION
Sorting numerically would cause a few of my comics to display the wrong image as the cover.
After investigating for a bit I found that case-insensitive natural sorting not only picked the correct cover for all my comics, but also matched the order that my comic viewer (mcomix) displays the archives.