### PR TITLE
spot-audio : implement usage of exiftool and rework of the global structure

### DIFF
--- a/spot-audio.yazi/README.md
+++ b/spot-audio.yazi/README.md
@@ -9,8 +9,7 @@ ya pkg add AminurAlam/yazi-plugins:spot AminurAlam/yazi-plugins:spot-audio
 # Dependencies
 
 - [spot.yazi](/spot.yazi) - backend plugin
-- [ffmpeg](https://repology.org/project/ffmpeg/versions) - for extracting metadata
-- [mediainfo](https://repology.org/project/mediainfo/versions) - used as fallback when ffmpeg is not available
+- [exiftool](https://repology.org/project/exiftool/versions) - for extracting metadata
 
 # Usage
 

--- a/spot-audio.yazi/main.lua
+++ b/spot-audio.yazi/main.lua
@@ -1,176 +1,121 @@
 local M = {}
 
----@param file File
----@return Sections
----@return Error?
-local audio_ffprobe = function(file)
-  -- stylua: ignore
-  local cmd = Command('ffprobe'):arg {
-    '-v', 'quiet',
-    '-show_entries', 'stream_tags:format:stream',
-    '-of', 'json=c=1',
-    file.name
-  }
+---@param section table
+---@param label string
+---@param value any
+local function add_field(section, label, value)
+	if value ~= nil and value ~= "" then
+		table.insert(section, { label, tostring(value) })
+	end
+end
 
-  local output, err = cmd:output()
-  if not output then
-    return {}, Err('Failed to start `ffprobe`, error: %s', err)
-  end
+---@param data Sections
+---@param section table
+local function add_section(data, section)
+	if #section > 0 then
+		table.insert(data, section)
+	end
+end
 
-  local json = ya.json_decode(output.stdout)
-  if not json then
-    return {}, Err('Failed to decode `ffprobe` output: %s', output.stdout)
-  elseif type(json) ~= 'table' then
-    return {}, Err('Invalid `ffprobe` output: %s', output.stdout)
-  end
-  -- ya.dbg(json)
+---@param value any
+---@return string
+local function join_tag(value)
+	if type(value) == "table" then
+		return table.concat(value, " / ")
+	end
+	return value or ""
+end
 
-  local audio_stream = json.streams[1]
-  local tags = json.format.tags or audio_stream.tags or audio_stream
-  local duration = json.format.duration
-  if duration then
-    duration = tonumber(duration)
-    duration = string.format('%d:%02d', math.floor(duration / 60), math.floor(duration % 60))
-  end
-
-  local data = {} ---@type Sections
-  local title, album, aar, ar =
-    tags.TITLE or tags.title or '',
-    tags.ALBUM or tags.album or '',
-    tags.ALBUM_ARTIST or tags.album_artist or '',
-    tags.ARTIST or tags.artist or ''
-
-  if title .. album .. ar .. aar ~= '' then
-    local img_stream = json.streams[2]
-    local date = tags.DATE or tags.date or 'No date'
-    local c = ''
-    local artist = ar
-
-    if tags.ORIGINALDATE and tags.ORIGINALDATE ~= '' then
-      date = date .. ' / ' .. tags.ORIGINALDATE
-    end
-    if (aar ~= '') and (aar ~= ar) then
-      artist = artist .. ' / ' .. aar
-    end
-    if img_stream then
-      c = img_stream.codec_name .. ' ' .. img_stream.width .. 'x' .. img_stream.height
-    end
-
-    data[#data + 1] = {
-      title = 'General',
-      { 'Title', title },
-      { 'Album', album },
-      { 'Artist', artist },
-      { 'Genre', tags.GENRE or tags.genre or 'No genre' },
-      { 'Date', date },
-      { 'Duration', duration },
-      c ~= '' and { 'Cover art', c } or nil,
-    }
-  end
-
-  local sr = audio_stream.sample_rate
-  if sr then
-    sr = string.format('%.1fkhz', sr / 1000)
-  end
-  local bd = audio_stream.bits_per_raw_sample or '1'
-  data[#data + 1] = {
-    title = 'Audio',
-    { 'Format', json.format.format_name },
-    { 'Quality', bd .. 'bit / ' .. sr },
-    {
-      'BitRate',
-      tonumber((audio_stream.bit_rate or json.format.bit_rate or 0) // 1000) .. ' kb/s',
-    },
-    { 'Channels', tostring(audio_stream.channels or '?') },
-  }
-
-  -- ya.dbg(data)
-  return data
+---@param ... any
+---@return any
+local function first(...)
+	for i = 1, select("#", ...) do
+		local v = select(i, ...)
+		if v ~= nil and v ~= "" then
+			return v
+		end
+	end
 end
 
 ---@param file File
 ---@return Sections
 ---@return Error?
-local audio_mediainfo = function(file)
-  local cmd = Command('mediainfo'):arg { '--Output=JSON', file.name }
+local audio_exiftool = function(file)
+	local cmd = Command("exiftool"):arg({
+		"-j",
+		"-a",
+		"-s",
+		file.name,
+	})
 
-  local output, err = cmd:output()
-  if not output then
-    return {}, Err('Failed to start `mediainfo`, error: %s', err)
-  end
+	local output, err = cmd:output()
+	if not output then
+		return {}, Err("Failed to start `exiftool`, error: %s", err)
+	end
 
-  local json = ya.json_decode(output.stdout)
-  if not json then
-    return {}, Err('Failed to decode `mediainfo` output: %s', output.stdout)
-  elseif type(json) ~= 'table' then
-    return {}, Err('Invalid `mediainfo` output: %s', output.stdout)
-  end
-  -- ya.dbg(json)
+	local json = ya.json_decode(output.stdout)
+	if not json then
+		return {}, Err("Failed to decode `exiftool` output: %s", output.stdout)
+	elseif type(json) ~= "table" then
+		return {}, Err("Invalid `exiftool` output: %s", output.stdout)
+	end
+	-- ya.dbg(json)
 
-  local data = {}
-  local general = json.media.track[1]
-  local audio = json.media.track[2]
-  local image = json.media.track[3]
-  local title, album, aar, ar =
-    general.Title or '', general.Album or '', general.Album_Performer or '', general.Performer or ''
+	local data = {} ---@type Sections
+	local tags = json[1] or {}
 
-  if title .. album .. ar .. aar ~= '' then
-    local csize = ''
-    local date = general.Recorded_Date
-    local artist = ar
+	local artist = join_tag(tags.Artist)
+	local title = tags.Title
+	local album = tags.Album
+	local genre = join_tag(tags.Genre)
+	local date = first(tags.Originaldate, tags.Date, tags.DateTimeOriginal, tags.CreateDate)
+	local duration = tags.Duration
+	local cover
+	if tags.PictureType then
+		cover = tags.PictureType
 
-    if general.extra and general.extra.ORIGINALDATE then
-      date = date .. ' / ' .. general.extra.ORIGINALDATE
-    end
-    if (aar ~= '') and (aar ~= ar) then
-      artist = artist .. ' / ' .. aar
-    end
-    if image then
-      csize = image.Format .. ' ' .. image.Height .. 'x' .. image.Width
-    end
+		if tags.PictureWidth and tags.PictureHeight then
+			cover = string.format("%s (%sx%s)", cover, tags.PictureWidth, tags.PictureHeight)
+		end
+	end
 
-    data[#data + 1] = {
-      title = 'General',
-      { 'Title', title },
-      { 'Album', album },
-      { 'Artist', ar .. (aar ~= ar and (' / ' .. aar) or '') },
-      { 'Genre', general.Genre },
-      { 'Date', date },
-      { 'Duration', general.Duration },
-      csize ~= '' and { 'Cover art', csize } or nil,
-    }
-  end
+	local gen_sec = { title = "General" }
+	add_field(gen_sec, "Title", title)
+	add_field(gen_sec, "Artist", artist)
+	add_field(gen_sec, "Album", album)
+	add_field(gen_sec, "Genre", genre)
+	add_field(gen_sec, "Duration", duration)
+	add_field(gen_sec, "Date", date)
+	add_field(gen_sec, "Cover", cover)
 
-  local br = tonumber((audio.BitRate or 0) // 1000) .. ' kb/s'
-  local sr = tonumber((audio.SamplingRate or 0) / 1000)
-  data[#data + 1] = {
-    title = 'Audio',
-    { 'Format', audio.Format .. ' ' .. audio.Compression_Mode },
-    { 'Quality', (audio.BitDepth or '1') .. '/' .. sr },
-    { 'BitRate', br },
-    { 'Channels', audio.Channels .. ' ' .. (audio.ChannelLayout or '') },
-    { 'Duration', audio.Duration },
-  }
+	local audio_sec = { title = "Audio" }
+	add_field(audio_sec, "Format", first(tags.AudioFormat, tags.FileType))
 
-  -- ya.dbg(data)
+	local sr = first(tags.AudioSampleRate, tags.SampleRate)
+	local bd = first(tags.AudioBitsPerSample, tags.BitsPerSample)
+	if sr then
+		sr = string.format("%.1f kHz", tonumber(sr) / 1000)
+	end
+	add_field(audio_sec, "Sample Rate", sr)
+	add_field(audio_sec, "Bit Depth", (bd and (bd .. " bit")))
+	add_field(audio_sec, "BitRate", first(tags.AvgBitrate, tags.AudioBitrate))
+	add_field(audio_sec, "Channels", first(tags.AudioChannels, tags.ChannelMode, tags.Channels))
 
-  return data
+	add_section(data, gen_sec)
+	add_section(data, audio_sec)
+
+	-- ya.dbg(data)
+	return data
 end
 
 ---@param job Job
 function M:spot(job)
-  local sections, err = audio_ffprobe(job.file)
-  if not sections or err then
-    ya.dbg(err)
-    sections, err = audio_mediainfo(job.file)
-    if not sections then
-      ya.dbg(err)
-    end
-  end
+	local sections, err = audio_exiftool(job.file)
+	if not sections or err then
+		ya.dbg(err)
+	end
 
-  if sections then
-    require('spot'):spot(job, sections)
-  end
+	require("spot"):spot(job, sections)
 end
 
 return M


### PR DESCRIPTION
Use `ExifTool` instead of `MediaInfo/FFprobe` for metadata extraction, as it preserves multi-valued tags (e.g. multiple artists, genres, labels), providing a more faithful representation of the original metadata.

Also refactor the implementation into a clearer structure (in my opinion). It may be worth moving the `add_section` and `add_field` helpers into the template utilities to encourage reuse across spotters.

Thanks for all your work on these plugins, they're genuinely awesome and a pleasure to build upon 🙂